### PR TITLE
Head to Head Matchup results and correct bug preventing multiple classes per season being viewable

### DIFF
--- a/src/lib/layouts/standings.astro
+++ b/src/lib/layouts/standings.astro
@@ -58,15 +58,23 @@ const finalData: Array<Record<string, any>> = standingsResults.map(
     };
   }
 );
-const generateLinkForKey = (key: string, resultAtKey: unknown) => {
+const generateLinkForKey = ({
+  key,
+  resultAtKey,
+  carClassId,
+}: {
+  key: string;
+  resultAtKey: unknown;
+  carClassId: string;
+}) => {
   if (key === "season_id") {
-    return `/Stat-N-Track/user/${id}/season/${resultAtKey}`;
+    return `/Stat-N-Track/user/${id}/season/${resultAtKey}/car-class/${carClassId}`;
   } else if (key === "year") {
     return `/Stat-N-Track/user/${id}/standings/by-year/${resultAtKey}`;
   } else if (key === "car_class_id") {
     return `/Stat-N-Track/user/${id}/standings/by-car-class/${resultAtKey}`;
   } else if (key === "Season Summary") {
-    return `/Stat-N-Track/user/${id}/season/${resultAtKey}/season-summary`;
+    return `/Stat-N-Track/user/${id}/season/${resultAtKey}/car-class/${carClassId}/season-summary`;
   }
   return null;
 };
@@ -97,11 +105,19 @@ const generateLinkForKey = (key: string, resultAtKey: unknown) => {
                 id={`${key}~${rowNumber}~${result[key]}`}
                 class="border-2"
               >
-                {generateLinkForKey(key, result[key]) ? (
+                {generateLinkForKey({
+                  key,
+                  resultAtKey: result[key],
+                  carClassId: result.car_class_id,
+                }) ? (
                   <a
                     class="underline"
                     rel="prefetch"
-                    href={generateLinkForKey(key, result[key])}
+                    href={generateLinkForKey({
+                      key,
+                      resultAtKey: result[key],
+                      carClassId: result.car_class_id,
+                    })}
                   >
                     {result[key]}
                   </a>

--- a/src/pages/shared-subsessions.astro
+++ b/src/pages/shared-subsessions.astro
@@ -14,7 +14,10 @@ const $and = userIds.map((userId) => ({
   "session_results.2.results": { $elemMatch: { cust_id: userId } },
 }));
 const subsessions = await collection.find({ $and }).sort({ _id: -1 }).toArray();
-const results:Array<{ subsessionInfo: Record<string,unknown>, session: Session}> = subsessions.map((subsession: Subsession) => {
+const results: Array<{
+  subsessionInfo: Record<string, unknown>;
+  session: Session;
+}> = subsessions.map((subsession: Subsession) => {
   const {
     subsession_id,
     track,
@@ -53,9 +56,9 @@ const results:Array<{ subsessionInfo: Record<string,unknown>, session: Session}>
   const session = {
     simsession_number: 0,
     simsession_type: 0,
-    simsession_type_name: '',
+    simsession_type_name: "",
     simsession_subtype: 0,
-    simsession_name: '',
+    simsession_name: "",
     results,
   };
   return {

--- a/src/pages/shared-subsessions.astro
+++ b/src/pages/shared-subsessions.astro
@@ -1,13 +1,12 @@
 ---
 import { connectToDatabase } from "$lib/mongodb";
-import type { Subsession } from "$lib/types";
+import type { Session, SessionResult, Subsession } from "$lib/types";
 import DefaultLayout from "$lib/layouts/default.astro";
 import RaceResults from "$lib/components/session-results/race.astro";
 import userIds from "$lib/utils/user-ids";
 import parseLapTime from "$lib/utils/parse-lap-time";
 import fieldIdToLabelMap from "$lib/utils/field-id-to-label-map";
 import keysToDisplay from "$lib/utils/race-session-keys-to-display";
-// @todo Fix all this nonsense you jankily slapped together at 2AM on a Saturday
 const dbConnection = await connectToDatabase();
 const { db } = dbConnection;
 const collection = db.collection<Subsession>("subsessions");
@@ -15,7 +14,7 @@ const $and = userIds.map((userId) => ({
   "session_results.2.results": { $elemMatch: { cust_id: userId } },
 }));
 const subsessions = await collection.find({ $and }).sort({ _id: -1 }).toArray();
-const results = subsessions.map((subsession: Subsession) => {
+const results:Array<{ subsessionInfo: Record<string,unknown>, session: Session}> = subsessions.map((subsession: Subsession) => {
   const {
     subsession_id,
     track,
@@ -32,24 +31,19 @@ const results = subsessions.map((subsession: Subsession) => {
   } = subsession;
   // Current Users in race session
   const results = subsession.session_results[2].results
-    .filter((v: any) => userIds.includes(v.cust_id))
-    .map((w) => {
-      // @todo figure out how to fix the typing here
-      // @ts-ignore
+    .filter((v: SessionResult) => userIds.includes(v.cust_id))
+    .map((w: SessionResult) => {
       return Object.keys(w).reduce((object, key) => {
         if (keysToDisplay.has(key)) {
           // @ts-ignore
           object[key] = w[key];
         }
         return object;
-      }, {});
-      // @ts-ignore
+      }, {} as SessionResult);
     })
-    .sort((x, y) => {
-      // @ts-ignore
+    .sort((x: SessionResult, y: SessionResult) => {
       if (x.finish_position > y.finish_position) {
         return 1;
-        // @ts-ignore
       } else if (y.finish_position > x.finish_position) {
         return -1;
       }
@@ -57,6 +51,11 @@ const results = subsessions.map((subsession: Subsession) => {
     });
   const { group_name: License } = allowed_licenses.slice(0, 2).pop() || {};
   const session = {
+    simsession_number: 0,
+    simsession_type: 0,
+    simsession_type_name: '',
+    simsession_subtype: 0,
+    simsession_name: '',
     results,
   };
   return {
@@ -79,7 +78,6 @@ const results = subsessions.map((subsession: Subsession) => {
     session,
   };
 });
-// @todo Don't cheat the types here
 export const handleKey = ({
   key,
   subsessionInfo,
@@ -105,7 +103,9 @@ export const handleKey = ({
     id="top"
     x-data={JSON.stringify(
       results.reduce((object, result) => {
+        //@ts-expect-error
         object.previouslyToggled = "";
+        //@ts-expect-error
         object[`toggle${result.subsessionInfo.subsession_id}`] = false;
         return object;
       }, {})
@@ -117,7 +117,7 @@ export const handleKey = ({
       {
         results.map((result) => (
           <div
-            id={result.subsessionInfo.subsession_id}
+            id={String(result.subsessionInfo.subsession_id)}
             x-cloak
             x-show={`toggle${result.subsessionInfo.subsession_id}`}
             x-transition:enter.duration.500ms

--- a/src/pages/shared-subsessions.astro
+++ b/src/pages/shared-subsessions.astro
@@ -14,6 +14,7 @@ const $and = userIds.map((userId) => ({
   "session_results.2.results": { $elemMatch: { cust_id: userId } },
 }));
 const subsessions = await collection.find({ $and }).sort({ _id: -1 }).toArray();
+const headToHeadWins: Record<string,Array<number>> = {};
 const results: Array<{
   subsessionInfo: Record<string, unknown>;
   session: Session;
@@ -52,6 +53,13 @@ const results: Array<{
       }
       return 0;
     });
+  const [winner] = results;
+  const { display_name } = winner;
+  if(headToHeadWins[display_name]) {
+    headToHeadWins[display_name].push(subsession_id)
+  } else {
+    headToHeadWins[display_name] = [subsession_id];
+  }
   const { group_name: License } = allowed_licenses.slice(0, 2).pop() || {};
   const session = {
     simsession_number: 0,
@@ -99,9 +107,28 @@ export const handleKey = ({
   }
   return String(subsessionInfo[key]);
 };
+const correctlyKeyedH2HWins = Object.keys((headToHeadWins)).reduce((object, key) => {
+  const wins = headToHeadWins[key].length;
+  object[key] = { key, wins };
+  return object;
+}, {} as Record<string,{ key: string, wins: number }>);
+const h2hOutput = Object.keys(correctlyKeyedH2HWins).map((key) => correctlyKeyedH2HWins[key]).sort((a, b) => {
+  if (a.wins > b.wins) {
+    return -1;
+  } else if (b.wins > a.wins) {
+    return 1;
+  }
+   return 0;
+});
 ---
 
 <DefaultLayout>
+  <div class="text-center lg:text-2xl md:text-md sm:text-sm py-4">
+    <div class="font-bold">Head to Head Wins</div>
+    {h2hOutput.map((value) => (
+      <div>{value.key}: {value.wins}</div>
+    ))}
+  </div>
   <div
     id="top"
     x-data={JSON.stringify(

--- a/src/pages/user/[id]/season/[seasonId]/car-class/[carClassId]/index.astro
+++ b/src/pages/user/[id]/season/[seasonId]/car-class/[carClassId]/index.astro
@@ -17,17 +17,20 @@ export async function getStaticPaths() {
     params: {
       id: Number(season.season_driver_data.cust_id),
       seasonId: Number(season.season_id),
+      carClassId: Number(season.car_class_id),
     },
   }));
 }
-const { id, seasonId } = Astro.params;
+const { id, seasonId, carClassId } = Astro.params;
 const dbConnection = await connectToDatabase();
 const db = dbConnection.db;
 const collection = db.collection<Subsession>("subsessions");
 const subsessions: Array<Subsession> = await collection
   .find({
     season_id: Number(seasonId),
-    "session_results.2.results": { $elemMatch: { cust_id: Number(id) } },
+    "session_results.2.results": {
+      $elemMatch: { cust_id: Number(id), car_class_id: Number(carClassId) },
+    },
   })
   .sort({ _id: 1 })
   .toArray();
@@ -160,7 +163,7 @@ const { keysArray, handledResults } = handleResults({ keysToDisplay, results });
     </div>
     <script>
       import Alpine from "alpinejs";
-      import Table from "../../../../../lib/components/table/index.ts";
+      import Table from "$lib/components/table/index.ts";
       Alpine.data("table", Table);
       Alpine.start();
     </script>

--- a/src/pages/user/[id]/season/[seasonId]/car-class/[carClassId]/season-summary.astro
+++ b/src/pages/user/[id]/season/[seasonId]/car-class/[carClassId]/season-summary.astro
@@ -12,7 +12,6 @@ import type {
   Track,
 } from "$lib/types";
 import userIds from "$lib/utils/user-ids";
-// @todo Properly assert types in this file
 export async function getStaticPaths() {
   const dbConnection = await connectToDatabase();
   const db = dbConnection.db;
@@ -24,24 +23,26 @@ export async function getStaticPaths() {
     params: {
       id: Number(season.season_driver_data.cust_id),
       seasonId: Number(season.season_id),
+      carClassId: Number(season.car_class_id),
     },
   }));
 }
-const { id, seasonId } = Astro.params;
+const { id, seasonId, carClassId } = Astro.params;
 const dbConnection = await connectToDatabase();
 const db = dbConnection.db;
 const subsessionCollection = db.collection<Subsession>("subsessions");
 const subsessions: Array<Subsession> = await subsessionCollection
   .find({
     season_id: Number(seasonId),
-    "session_results.2.results": { $elemMatch: { cust_id: Number(id) } },
+    "session_results.2.results": {
+      $elemMatch: { cust_id: Number(id), car_class_id: Number(carClassId) },
+    },
   })
   .sort({ _id: 1 })
   .toArray();
 const standingsCollection = db.collection("standings");
 const season = await standingsCollection.findOne({
-  "season_driver_data.cust_id": Number(id),
-  season_id: String(seasonId),
+  _id: `${seasonId}_${carClassId}_${id}`,
 });
 const pastSeasonsCollection = db.collection("pastseasons");
 const pastSeasonInformation = await pastSeasonsCollection.findOne({
@@ -85,8 +86,10 @@ trackScheduleMap.forEach((value) => {
       resultsPerWeek.push(bestUserResult);
     }
   } else if (userResults.length === 0) {
-    const bestUserResult = { subsession: { track: value }, userResult: {} };
-    // @ts-expect-error
+    const bestUserResult = {
+      subsession: { track: value } as Subsession,
+      userResult: {} as SessionResult,
+    };
     resultsPerWeek.push(bestUserResult);
   } else {
     const [bestUserResult] = userResults;
@@ -123,11 +126,10 @@ const results = resultsPerWeek.map((result) => {
     car_name,
     aggregate_champ_points,
   } = userResult;
-  // @ts-expect-error
   const { group_name: License } =
     allowed_licenses && allowed_licenses.length
-      ? allowed_licenses.slice(0, 2).pop()
-      : {};
+      ? (allowed_licenses.slice(0, 2).pop() as License)
+      : ({} as License);
   const sof = {
     "Strength Of Field": subsession.race_summary
       ? subsession.race_summary.field_strength


### PR DESCRIPTION
In this PR:

- (Generally speaking), Correct shared-subessions typing. https://github.com/Shinsina/Stat-N-Track/commit/ea69d2073c11361f802f8917a6761d41945e1466
- Format shared-subsessions.astro. https://github.com/Shinsina/Stat-N-Track/commit/6b72ab1a4175bbd9cfc5e53951c5123d301d0bc9
- Correct inability to view multiple car classes per season. https://github.com/Shinsina/Stat-N-Track/commit/1c547690a119f489608cefb26a22a80d5f68519d
- Display Head to Head Wins at top of shared subsessions page. https://github.com/Shinsina/Stat-N-Track/commit/f9d4f9ef62205eb3fca564ce27bf0d4d6d08ef97