### PR TITLE
Scheduling and Subsessions By Track Page Additions, additional corrections

### DIFF
--- a/src/lib/layouts/standings.astro
+++ b/src/lib/layouts/standings.astro
@@ -25,7 +25,8 @@ const finalData: Array<Record<string, any>> = standingsResults.map(
       incidents,
       points,
     } = result;
-    const [, year] = season_name.match(/([0-9]{4}) Season/) || [0, 0];
+    const [, year] = season_name.match(/([0-9]{4}) Season/) ||
+      season_name.match(/([0-9]{4})$/) || [0, 0];
     const [, season_number_of_year] = season_name.match(
       /Season ([0-9]{1})/
     ) || [0, 0];

--- a/src/lib/layouts/subsessions.astro
+++ b/src/lib/layouts/subsessions.astro
@@ -66,7 +66,7 @@ const results = subsessions.map((subsession: Subsession) => {
     aggregate_champ_points,
   };
 });
-const keysToDisplay = new Set(Object.keys(results[0]));
+const keysToDisplay = new Set(Object.keys(results[0] || {}));
 const { keysArray, handledResults } = handleResults({ keysToDisplay, results });
 ---
 

--- a/src/lib/utils/determine-start-of-week-for-date-string.ts
+++ b/src/lib/utils/determine-start-of-week-for-date-string.ts
@@ -1,0 +1,25 @@
+export default ({
+  object,
+  dateString,
+}: {
+  object: Record<string, Array<string>>;
+  dateString: string;
+}) => {
+  const d = new Date(String(dateString));
+  const day = d.getDay();
+  const utcDateString = d.toUTCString();
+  if (day === 1 && !object[utcDateString]) {
+    object[utcDateString] = [utcDateString];
+  } else if (day !== 1) {
+    const distanceFromOne = day - 1;
+    const dayOneOfWeek = new Date(
+      Number(d) - distanceFromOne * 86400000
+    ).toUTCString();
+    if (object[dayOneOfWeek]) {
+      object[dayOneOfWeek].push(utcDateString);
+    } else {
+      object[dayOneOfWeek] = [utcDateString];
+    }
+  }
+  return object;
+};

--- a/src/lib/utils/generate-season-weeks.ts
+++ b/src/lib/utils/generate-season-weeks.ts
@@ -1,0 +1,46 @@
+import determineStartOfWeekForDateString from "$lib/utils/determine-start-of-week-for-date-string";
+
+export default ({
+  seasons,
+}: {
+  seasons: Array<{ schedules: Array<{ start_date: string }> }>;
+}) => {
+  const seasonStart = Date.UTC(2024, 2, 12, 0, 0, 0, 0);
+  const seasonEnd = Date.UTC(2024, 4, 28, 0, 0, 0, 0);
+  const startDates = seasons.reduce(
+    (
+      set: Set<string>,
+      season: { schedules: Array<{ start_date: string }> }
+    ) => {
+      const { schedules } = season;
+      if (Array.isArray(schedules)) {
+        schedules.forEach((schedule) => {
+          const { start_date } = schedule;
+          const [year, month, day] = start_date.split("-");
+          const date = Date.UTC(
+            Number(year),
+            Number(month) - 1,
+            Number(day),
+            0,
+            0,
+            0,
+            0
+          );
+          if (date >= seasonStart && date <= seasonEnd) {
+            set.add(start_date);
+          }
+        });
+      }
+      return set;
+    },
+    new Set([]) as Set<string>
+  );
+  const weeks = Array.from(startDates)
+    .sort()
+    .reduce<Record<string, Array<string>>>(
+      (object, dateString) =>
+        determineStartOfWeekForDateString({ object, dateString }),
+      {}
+    );
+  return weeks;
+};

--- a/src/lib/utils/generate-track-map.ts
+++ b/src/lib/utils/generate-track-map.ts
@@ -1,0 +1,27 @@
+import type { Track } from "$lib/types";
+
+export default ({ tracks }: { tracks: Array<{ track: Track }> }) => {
+  return tracks.reduce<Map<string, { trackName: string; configName: string }>>(
+    (
+      map: Map<string, { trackName: string; configName: string }>,
+      trackObject
+    ) => {
+      const { track } = trackObject as { track: Track };
+      const trackName = `${track.track_name} ${track.config_name}`;
+      map.set(
+        trackName
+          .toLowerCase()
+          .replace(/[\(\)\[\]]/g, "")
+          .replace(/[ \/]/g, "-")
+          .replace("---", "-")
+          .replace("-n-a", ""),
+        {
+          trackName: track.track_name || "",
+          configName: track.config_name || "",
+        }
+      );
+      return map;
+    },
+    new Map([]) as Map<string, { trackName: string; configName: string }>
+  );
+};

--- a/src/pages/user/[id]/index.astro
+++ b/src/pages/user/[id]/index.astro
@@ -22,6 +22,13 @@ const description = `User page for user ID: ${id}`;
       <a
         class="underline"
         rel="prefetch"
+        href=`/Stat-N-Track/user/${id}/scheduling/by-week`>Scheduling By Week</a
+      >
+    </div>
+    <div>
+      <a
+        class="underline"
+        rel="prefetch"
         href=`/Stat-N-Track/user/${id}/subsessions`>All Sessions</a
       >
     </div>
@@ -38,6 +45,14 @@ const description = `User page for user ID: ${id}`;
         rel="prefetch"
         href=`/Stat-N-Track/user/${id}/subsessions/by-car-class`
         >Sessions By Car Class</a
+      >
+    </div>
+    <div>
+      <a
+        class="underline"
+        rel="prefetch"
+        href=`/Stat-N-Track/user/${id}/subsessions/by-track`
+        >Sessions By Track</a
       >
     </div>
     <div>

--- a/src/pages/user/[id]/scheduling/by-week/[timestamp].astro
+++ b/src/pages/user/[id]/scheduling/by-week/[timestamp].astro
@@ -1,0 +1,194 @@
+---
+import { db, eq, User, Car, CarClass, Season } from "astro:db";
+import DefaultLayout from "$lib/layouts/default.astro";
+import generateSeasonWeeks from "$lib/utils/generate-season-weeks";
+import determineStartOfWeekForDateString from "$lib/utils/determine-start-of-week-for-date-string";
+export async function getStaticPaths() {
+  const userIds = await db.selectDistinct({ id: User.cust_id }).from(User);
+  const seasonsFromDb = await db.select().from(Season);
+  const seasons = seasonsFromDb as Array<{
+    schedules: Array<{ start_date: string }>;
+  }>;
+  const weeks = generateSeasonWeeks({ seasons });
+  return userIds
+    .map(({ id }) => {
+      return Object.keys(weeks).map((weekStart) => ({
+        params: { id, timestamp: String(Number(new Date(weekStart))) },
+      }));
+    })
+    .flat();
+}
+const { id, timestamp } = Astro.params;
+const [user] = await db
+  .select({
+    carPackages: User.car_packages,
+    trackPackages: User.track_packages,
+  })
+  .from(User)
+  .where(eq(User.cust_id, id));
+const { carPackages, trackPackages } = user;
+const carIds = Array.isArray(carPackages)
+  ? carPackages.map((carPackage) => carPackage.content_ids).flat()
+  : [];
+const trackIds = Array.isArray(trackPackages)
+  ? trackPackages.map((trackPackage) => trackPackage.content_ids).flat()
+  : [];
+const cars = await db.select().from(Car);
+const carsMap = new Map();
+cars.forEach((car) => {
+  const { car_id } = car;
+  carsMap.set(car_id, car);
+});
+// @todo Improve this query to not have to do this
+const carClassesResults = await db
+  .select({
+    carClassId: CarClass.car_class_id,
+    carsInClass: CarClass.cars_in_class,
+  })
+  .from(CarClass);
+const carClassIdsForCarIds = carClassesResults
+  .filter((result: any) =>
+    result.carsInClass.some((v: any) => carIds.includes(v.car_id))
+  )
+  .map((result) => result.carClassId);
+// End comment of previous todo
+const carClasses = await db.select().from(CarClass);
+const carClassesMap = new Map();
+carClasses.forEach((carClass) => {
+  const { car_class_id, cars_in_class } = carClass;
+  const carsInClass = Array.isArray(cars_in_class)
+    ? cars_in_class.map((carInClass) => carsMap.get(carInClass.car_id))
+    : [];
+  carClassesMap.set(car_class_id, { ...carClass, cars_in_class: carsInClass });
+});
+const carClassIdSet = new Set(carClassIdsForCarIds);
+const trackIdSet = new Set(trackIds);
+const licenseGroupToNameMap: Record<string, string> = {
+  "1": "Rookie",
+  "2": "Class D",
+  "3": "Class C",
+  "4": "Class B",
+  "5": "Class A",
+};
+const seasons = await db.select().from(Season);
+const schedulesForWeek = seasons.reduce(
+  (array: Array<Record<string, unknown>>, season) => {
+    const { schedules, ...rest } = season;
+    if (Array.isArray(schedules)) {
+      const scheduleForWeek = schedules.find(
+        (schedule) =>
+          Number(
+            new Date(
+              String(
+                Object.keys(
+                  determineStartOfWeekForDateString({
+                    object: {},
+                    dateString: schedule.start_date,
+                  })
+                ).pop()
+              )
+            )
+          ) === Number(timestamp)
+      );
+      if (scheduleForWeek) {
+        const ownTrack = trackIdSet.has(scheduleForWeek.track.track_id);
+        const ownCar = () => {
+          if (scheduleForWeek.race_week_cars?.length) {
+            return Boolean(
+              scheduleForWeek.race_week_cars.filter((car: { car_id: Number }) =>
+                carIds.includes(car.car_id)
+              ).length
+            );
+          }
+          const ownedCarClasses = Array.isArray(rest.car_class_ids)
+            ? rest.car_class_ids.filter((carClassId) =>
+                carClassIdSet.has(carClassId)
+              )
+            : [];
+          return Boolean(ownedCarClasses.length);
+        };
+        array.push({
+          Season_Name: rest.season_name,
+          Track_Name:
+            `${scheduleForWeek.track.track_name} ${scheduleForWeek.track.config_name || ""}`.trim(),
+          Own_Car: ownCar() ? "Yes" : "No",
+          Own_Track: ownTrack ? "Yes" : "No",
+          Schedule_Description: rest.schedule_description,
+          License_Level: licenseGroupToNameMap[String(rest.license_group)],
+        });
+      }
+    }
+    return array;
+  },
+  []
+);
+const title = `Scheduling By Week - ${id} and week starting ${new Date(Number(timestamp)).toUTCString()}`;
+const description = title;
+---
+
+<DefaultLayout {title} {description}>
+  <div class="grid grid-cols-1 pt-6 overflow-x-scroll">
+    <div class="text-center col-span-1 text-2xl pb-6">
+      <p>Week Starts</p>
+      <p>
+        {
+          new Date(Number(timestamp)).toLocaleString("en-US", {
+            timeZone: "America/Chicago",
+          })
+        }
+      </p>
+      <p>This is: {new Date(Number(timestamp)).toUTCString()}</p>
+      <p>This is considered "even" with the alternating hour being "odd"</p>
+    </div>
+    <table x-ref="Table" x-data="table" class="text-center col-span-1">
+      <tr x-ref="Headings"
+        >{
+          Object.keys(schedulesForWeek[0]).map((key) => (
+            <th
+              id={`Table ${key} ${schedulesForWeek.length}`}
+              class="border-2"
+              x-on:click="sort"
+            >
+              {key.replace("_", " ")}
+            </th>
+          ))
+        }</tr
+      >
+      {
+        schedulesForWeek.map((result, rowNumber) =>
+          result.Own_Track === "Yes" && result.Own_Car === "Yes" ? (
+            <tr class="bg-green-950" x-ref={`Table ${rowNumber}`}>
+              {Object.keys(result).map((key: string) => (
+                <td
+                  x-ref={`Table ${key} ${rowNumber}`}
+                  id={`${key}~${rowNumber}~${result[key]}`}
+                  class="border-2"
+                >
+                  {result[key]}
+                </td>
+              ))}
+            </tr>
+          ) : (
+            <tr class="bg-red-950" x-ref={`Table ${rowNumber}`}>
+              {Object.keys(result).map((key: string) => (
+                <td
+                  x-ref={`Table ${key} ${rowNumber}`}
+                  id={`${key}~${rowNumber}~${result[key]}`}
+                  class="border-2"
+                >
+                  {result[key]}
+                </td>
+              ))}
+            </tr>
+          )
+        )
+      }
+    </table>
+  </div>
+  <script>
+    import Alpine from "alpinejs";
+    import Table from "$lib/components/table/index.ts";
+    Alpine.data("table", Table);
+    Alpine.start();
+  </script>
+</DefaultLayout>

--- a/src/pages/user/[id]/scheduling/by-week/index.astro
+++ b/src/pages/user/[id]/scheduling/by-week/index.astro
@@ -16,6 +16,6 @@ const description = `Scheduling by week page for user ID: ${id}`;
 
 <DefaultLayout {title} {description}>
   <div class="text-center text-3xl">
-    {Object.keys(weeks).map((week) => (<div><a class="underline" href=`/Stat-N-Track/user/${id}/scheduling/by-week/${Number(new Date(week))}` rel="prefetch">{new Date(week).toLocaleString()}</a></div>))}
+    {Object.keys(weeks).map((week) => (<div><a class="underline" href=`/Stat-N-Track/user/${id}/scheduling/by-week/${Number(new Date(week))}` rel="prefetch">{new Date(week).toLocaleString("en-US", { timeZone: "America/Chicago" })}</a></div>))}
   </div>
 </DefaultLayout>

--- a/src/pages/user/[id]/scheduling/by-week/index.astro
+++ b/src/pages/user/[id]/scheduling/by-week/index.astro
@@ -1,0 +1,21 @@
+---
+import { db, User, Season } from "astro:db";
+import DefaultLayout from "$lib/layouts/default.astro";
+import generateSeasonWeeks from "$lib/utils/generate-season-weeks";
+export async function getStaticPaths() {
+  const userIds = await db.selectDistinct({ id: User.cust_id }).from(User);
+  return userIds.map(({ id }) => ({ params: { id } }));
+}
+const { id } = Astro.params;
+const seasonsFromDb = await db.select().from(Season);
+const seasons = seasonsFromDb as  Array<{ schedules: Array<{ start_date: string }> }>;
+const weeks = generateSeasonWeeks({ seasons });
+const title = `Scheduling By Week - ${id}`;
+const description = `Scheduling by week page for user ID: ${id}`;
+---
+
+<DefaultLayout {title} {description}>
+  <div class="text-center text-3xl">
+    {Object.keys(weeks).map((week) => (<div><a class="underline" href=`/Stat-N-Track/user/${id}/scheduling/by-week/${Number(new Date(week))}` rel="prefetch">{new Date(week).toLocaleString()}</a></div>))}
+  </div>
+</DefaultLayout>

--- a/src/pages/user/[id]/standings/full-participation.astro
+++ b/src/pages/user/[id]/standings/full-participation.astro
@@ -7,7 +7,7 @@ export function getStaticPaths() {
 }
 const { id } = Astro.params;
 const seoTitle = `Fully Participated Standings - ${id}`;
-const seoDescription = `Fully partipacipated standings page for user ID: ${id}`;
+const seoDescription = `Fully participated standings page for user ID: ${id}`;
 const standingsResults = await db
   .select()
   .from(Standing)

--- a/src/pages/user/[id]/subsessions/by-track/[trackSlug].astro
+++ b/src/pages/user/[id]/subsessions/by-track/[trackSlug].astro
@@ -1,0 +1,101 @@
+---
+import {
+  db,
+  eq,
+  desc,
+  sql,
+  like,
+  and,
+  SubsessionRaceResults,
+  Subsession,
+} from "astro:db";
+import SubsessionsLayout from "$lib/layouts/subsessions.astro";
+import userIds from "$lib/utils/user-ids";
+import type { Track } from "$lib/types";
+import generateTrackMap from "$lib/utils/generate-track-map";
+export async function getStaticPaths() {
+  const mappings = await Promise.all(
+    userIds.map(async (userId) => {
+      const subsessions = await db
+        .selectDistinct({ subsession_id: SubsessionRaceResults.subsession_id })
+        .from(SubsessionRaceResults)
+        .where(eq(SubsessionRaceResults.cust_id, Number(userId)));
+      const tracks = await db
+        .selectDistinct({ track: Subsession.track })
+        .from(Subsession)
+        .where(
+          sql`${Subsession.subsession_id} IN ${subsessions.map((subsession) => subsession.subsession_id)}`
+        );
+      return { userId, tracks };
+    })
+  );
+  return mappings
+    .map((mapping) => {
+      const { userId, tracks } = mapping;
+      return tracks.map((trackMapping) => {
+        const { track } = trackMapping as { track: Track };
+        return {
+          params: {
+            id: userId,
+            trackSlug: `${track.track_name} ${track.config_name}`
+              .toLowerCase()
+              .replace(/[\(\)\[\]]/g, "")
+              .replace(/[ \/]/g, "-")
+              .replace("---", "-")
+              .replace("-n-a", ""),
+          },
+        };
+      });
+    })
+    .flat();
+}
+const { id, trackSlug } = Astro.params;
+const seoTitle = `Subsessions list for user ID - ${id} and track - ${trackSlug}`;
+const seoDescription = seoTitle;
+const blah = await db
+  .selectDistinct({ subsession_id: SubsessionRaceResults.subsession_id })
+  .from(SubsessionRaceResults)
+  .where(eq(SubsessionRaceResults.cust_id, Number(id)));
+const tracksFromDb: Array<{ track: unknown | Track }> = await db
+  .selectDistinct({ track: Subsession.track })
+  .from(Subsession)
+  .where(
+    sql`${Subsession.subsession_id} IN ${blah.map((subsession) => subsession.subsession_id)}`
+  );
+const tracks = tracksFromDb as Array<{ track: Track }>;
+const generatedTrackMap = generateTrackMap({ tracks });
+const { trackName, configName } = generatedTrackMap.get(trackSlug) || {};
+const subsessionsWithoutResult = await db
+  .select()
+  .from(Subsession)
+  .where(
+    and(
+      like(Subsession.track, `%${trackName}%`),
+      like(Subsession.track, `%${configName}%`)
+    )
+  )
+  .orderBy(desc(Subsession.subsession_id));
+const subsessionRaceResults = await db
+  .select()
+  .from(SubsessionRaceResults)
+  .where(
+    // @ts-ignore
+    sql`${SubsessionRaceResults.cust_id} IS ${id} AND ${SubsessionRaceResults.subsession_id} IN ${subsessionsWithoutResult.filter((subsession) => subsession.track?.track_name === trackName && subsession.track?.config_name === configName).map((subsessionWithoutResult) => subsessionWithoutResult.subsession_id)}`
+  );
+
+const subsessions = subsessionsWithoutResult
+  .map((subsessionWithoutResult) => {
+    const { subsession_id } = subsessionWithoutResult;
+    const userResult = subsessionRaceResults.find(
+      (subsessionRaceResult) =>
+        subsessionRaceResult.subsession_id === subsession_id
+    );
+    return {
+      ...subsessionWithoutResult,
+      userResult,
+    };
+  })
+  .filter((v) => v.userResult);
+---
+
+<SubsessionsLayout {id} {seoTitle} {seoDescription} {subsessions} />

--- a/src/pages/user/[id]/subsessions/by-track/index.astro
+++ b/src/pages/user/[id]/subsessions/by-track/index.astro
@@ -1,0 +1,31 @@
+---
+import { db, eq, sql, SubsessionRaceResults, Subsession } from "astro:db";
+import DefaultLayout from "$lib/layouts/default.astro";
+import userIds from "$lib/utils/user-ids";
+import type { Track } from "$lib/types";
+import generateTrackMap from "$lib/utils/generate-track-map";
+export function getStaticPaths() {
+  return userIds.map((id) => ({ params: { id } }));
+}
+const { id } = Astro.params;
+const subsessions = await db
+  .selectDistinct({ subsession_id: SubsessionRaceResults.subsession_id })
+  .from(SubsessionRaceResults)
+  .where(eq(SubsessionRaceResults.cust_id, Number(id)));
+const tracksFromDb = await db
+  .selectDistinct({ track: Subsession.track })
+  .from(Subsession)
+  .where(
+    sql`${Subsession.subsession_id} IN ${subsessions.map((subsession) => subsession.subsession_id)}`
+  );
+const tracks = tracksFromDb as Array<{ track: Track }>
+const trackMap = generateTrackMap({ tracks });
+const title = `Subsessions By Track - ${id}`;
+const description = `Subsessions by track page for user ID: ${id}`;
+---
+
+<DefaultLayout {title} {description}>
+  <div class="text-center text-3xl">
+    {Array.from(trackMap).sort().map(([key, track]) => (<div><a class="underline" href=`/Stat-N-Track/user/${id}/subsessions/by-track/${key}` rel="prefetch">{track.trackName} {track.configName.replace('N/A', '')}</a></div>))}
+	</div>
+</DefaultLayout>


### PR DESCRIPTION
In this PR:

- Correct spelling of seoDescription. https://github.com/Shinsina/Stat-N-Track/commit/d89301351efdf05f06e94a93c8b1b95f013e2418
- Fall back to any 4 digit number in the season_name (at end of season_name). https://github.com/Shinsina/Stat-N-Track/commit/4b7b534106ba0e0d9dc58ed075fba01f6a4dcac9
- Prevent error when results[0] is not an object. https://github.com/Shinsina/Stat-N-Track/commit/3bf063c67ed3a9c0e6a8458c5c4ed8a6acd4cad3
- Add generate-track-map utility. https://github.com/Shinsina/Stat-N-Track/commit/32060c98b0b0d81c9a62caec6d455c19e9ed6898
- Create subsessions-by-track index page.https://github.com/Shinsina/Stat-N-Track/commit/6a001446de93bbe5a9ee0496a2f87c6ccaf2eaeb
- Create subsessions by track individual track page. https://github.com/Shinsina/Stat-N-Track/commit/deaf199124b60a89f1541733211ca3cc63649f00
- Include determine-start-of-week-for-date-string-utility. https://github.com/Shinsina/Stat-N-Track/commit/4d5f97481900465d2dd1e94bd2d190904d11c169
- Include generate-season-weeks-utility, https://github.com/Shinsina/Stat-N-Track/commit/c33732471dc9c5ea03a98f61da4a0b9b6381817d
- Including Scheduling By Week landing page. https://github.com/Shinsina/Stat-N-Track/commit/eca93012194d4ad72913005a0493db5667ef92e3
- Including scheduling for week page. https://github.com/Shinsina/Stat-N-Track/commit/723617489220f12d30d1912a7c1c37ba0b67b12a
- Ensure America/Chicago is used for localeString. https://github.com/Shinsina/Stat-N-Track/commit/67471401228e1aa729e4e85322a812bd6dc5e879
- Add navigation for new pages. https://github.com/Shinsina/Stat-N-Track/commit/cdd1821536de6dae61b4db6cff34ffaff0d25342